### PR TITLE
Fix misbehaviour on updateUser for NodeBB >= v1.5

### DIFF
--- a/library.js
+++ b/library.js
@@ -243,6 +243,7 @@ plugin.createUser = function(payload, callback) {
 
 		var query = {
 			updateProfile: async.apply(user.updateProfile, uid, {
+				uid: uid,
 				fullname: [firstName, lastName].join(' ').trim(),
 				location: location,
 				website: website
@@ -292,6 +293,7 @@ plugin.updateUser = function(payload, callback) {
 
 	var query = {
 		updateProfile: async.apply(user.updateProfile, uid, {
+			uid: uid,
 			username: username,
 			fullname: [firstName, lastName].join(' ').trim(),
 			location: location,


### PR DESCRIPTION
The caller's UID and the profile's UID have been separeted in calls to
updateProfile (https://github.com/NodeBB/NodeBB/issues/5357). This fix
should remain compatible to the old behaviour (untested).